### PR TITLE
Add read only property support

### DIFF
--- a/Giver.Tests/ComplexTests.cs
+++ b/Giver.Tests/ComplexTests.cs
@@ -42,6 +42,14 @@ namespace Giver.Tests {
 
             Assert.Equal(testModels.Count, 5);
         }
+
+        [Fact]
+        public void ReadOnly_Property()
+        {
+            OrderLine orderLine = _give.Me<OrderLine>();
+
+            Assert.Equal(orderLine.Price * orderLine.Quantity, orderLine.TotalPrice);
+        }
     }
 
     public class CustomStringGenerator: StringGenerator {

--- a/Giver.Tests/ComplexTests.cs
+++ b/Giver.Tests/ComplexTests.cs
@@ -46,7 +46,8 @@ namespace Giver.Tests {
         [Fact]
         public void ReadOnly_Property()
         {
-            OrderLine orderLine = _give.Me<OrderLine>();
+            OrderLine orderLine = _give.Me<OrderLine>()
+                .With(ol => ol.Quantity = 1);
 
             Assert.Equal(orderLine.Price * orderLine.Quantity, orderLine.TotalPrice);
         }

--- a/Giver.Tests/Model/OrderLine.cs
+++ b/Giver.Tests/Model/OrderLine.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Giver.Tests.Model
+{
+    public class OrderLine
+    {
+        public int Id { get; set; }
+        public decimal Price { get; set; }
+        public int Quantity { get; set; }
+        public decimal TotalPrice => Price * Quantity;
+    }
+}

--- a/Giver/Helper.cs
+++ b/Giver/Helper.cs
@@ -14,7 +14,7 @@ namespace Giver {
 #else
             return type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
 #endif
-                .Where(p => IsPrimitive(p.PropertyType))
+                .Where(p => IsPrimitive(p.PropertyType) && p.HasSetter())
                 .Select(p => new Member(p, p.PropertyType))
 #if NET_40
                 .Union(type.GetFields()
@@ -31,6 +31,15 @@ namespace Giver {
             return type.GetTypeInfo().IsValueType || type == typeof(string);
 #else
             return type.IsValueType || type == typeof(string);
+#endif
+        }
+
+        public static bool HasSetter(this PropertyInfo propertyInfo)
+        {
+#if NET_40
+            return propertyInfo.GetSetMethod() != null;
+#else
+            return propertyInfo.SetMethod != null;
 #endif
         }
 


### PR DESCRIPTION
Currently the builder attempts to call setters even if they don't exist.

Reproduce with test **ComplexTests.ReadOnly_Property**

Fix was simply to check for the existence of a setter.